### PR TITLE
refactor generateNewCertificate method

### DIFF
--- a/pkg/sentry/ca/certificate_authority.go
+++ b/pkg/sentry/ca/certificate_authority.go
@@ -1,6 +1,7 @@
 package ca
 
 import (
+	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
@@ -224,59 +225,70 @@ func (c *defaultCA) generateRootAndIssuerCerts() (*certs.Credentials, []byte, []
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	rootCsr, err := csr.GenerateRootCertCSR(caOrg, caCommonName, &rootKey.PublicKey, selfSignedRootCertLifetime, c.config.AllowedClockSkew)
+	certsCredentials, rootCertPem, issuerCertPem, issuerKeyPem, err := GetNewSelfSignedCertificates(
+		rootKey, selfSignedRootCertLifetime, c.config.AllowedClockSkew)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-
-	rootCertBytes, err := x509.CreateCertificate(rand.Reader, rootCsr, rootCsr, &rootKey.PublicKey, rootKey)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	rootCertPem := pem.EncodeToMemory(&pem.Block{Type: certs.BlockTypeCertificate, Bytes: rootCertBytes})
-
-	rootCert, err := x509.ParseCertificate(rootCertBytes)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	issuerKey, err := certs.GenerateECPrivateKey()
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	issuerCsr, err := csr.GenerateIssuerCertCSR(caCommonName, &issuerKey.PublicKey, selfSignedRootCertLifetime, c.config.AllowedClockSkew)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	issuerCertBytes, err := x509.CreateCertificate(rand.Reader, issuerCsr, rootCert, &issuerKey.PublicKey, rootKey)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	issuerCertPem := pem.EncodeToMemory(&pem.Block{Type: certs.BlockTypeCertificate, Bytes: issuerCertBytes})
-
-	encodedKey, err := x509.MarshalECPrivateKey(issuerKey)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	issuerKeyPem := pem.EncodeToMemory(&pem.Block{Type: certs.BlockTypeECPrivateKey, Bytes: encodedKey})
-
-	issuerCert, err := x509.ParseCertificate(issuerCertBytes)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
 	// store credentials so that next time sentry restarts it'll load normally
 	err = certs.StoreCredentials(c.config, rootCertPem, issuerCertPem, issuerKeyPem)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
+	return certsCredentials, rootCertPem, issuerCertPem, nil
+}
+
+func GetNewSelfSignedCertificates(
+	rootKey *ecdsa.PrivateKey,
+	selfSignedRootCertLifetime,
+	allowedClockSkew time.Duration) (*certs.Credentials, []byte, []byte, []byte, error) {
+	rootCsr, err := csr.GenerateRootCertCSR(caOrg, caCommonName, &rootKey.PublicKey, selfSignedRootCertLifetime, allowedClockSkew)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	rootCertBytes, err := x509.CreateCertificate(rand.Reader, rootCsr, rootCsr, &rootKey.PublicKey, rootKey)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	rootCertPem := pem.EncodeToMemory(&pem.Block{Type: certs.BlockTypeCertificate, Bytes: rootCertBytes})
+
+	rootCert, err := x509.ParseCertificate(rootCertBytes)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	issuerKey, err := certs.GenerateECPrivateKey()
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	issuerCsr, err := csr.GenerateIssuerCertCSR(caCommonName, &issuerKey.PublicKey, selfSignedRootCertLifetime, allowedClockSkew)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	issuerCertBytes, err := x509.CreateCertificate(rand.Reader, issuerCsr, rootCert, &issuerKey.PublicKey, rootKey)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	issuerCertPem := pem.EncodeToMemory(&pem.Block{Type: certs.BlockTypeCertificate, Bytes: issuerCertBytes})
+
+	encodedKey, err := x509.MarshalECPrivateKey(issuerKey)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	issuerKeyPem := pem.EncodeToMemory(&pem.Block{Type: certs.BlockTypeECPrivateKey, Bytes: encodedKey})
+
+	issuerCert, err := x509.ParseCertificate(issuerCertBytes)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
 	return &certs.Credentials{
 		PrivateKey:  issuerKey,
 		Certificate: issuerCert,
-	}, rootCertPem, issuerCertPem, nil
+	}, rootCertPem, issuerCertPem, issuerKeyPem, nil
 }


### PR DESCRIPTION
Signed-off-by: Pravin Pushkar <ppushkar@microsoft.com>

# Description
Some of these exported const are being used in CLI during certificate renewal process please take a look here - https://github.com/dapr/cli/blob/0c514816cdc5de73bc0106a922103293bf810926/pkg/kubernetes/renew_certificate.go#L181

We can refactor this method so that CLI can become independent of internal implementation of these methods.
 
<!--
Please explain the changes you've made.
-->

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
